### PR TITLE
Migrate to null safety

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## [0.2.0]
+
+* Migrate to null safety
+* Require Dart SDK 2.12 or later
+
 ## [0.1.2]
 
 * Web support

--- a/lib/src/packer.dart
+++ b/lib/src/packer.dart
@@ -21,9 +21,9 @@ class Packer {
 
   int _bufSize;
 
-  Uint8List _buf;
-  ByteData _d;
-  int _offset;
+  late Uint8List _buf;
+  late ByteData _d;
+  int _offset = 0;
 
   void _newBuf(int size) {
     _buf = Uint8List(size);
@@ -72,7 +72,7 @@ class Packer {
   }
 
   /// Pack [bool] or `null`.
-  void packBool(bool v) {
+  void packBool(bool? v) {
     if (_buf.length - _offset < 1) _nextBuf();
     if (v == null) {
       _d.setUint8(_offset++, 0xc0);
@@ -82,7 +82,7 @@ class Packer {
   }
 
   /// Pack [int] or `null`.
-  void packInt(int v) {
+  void packInt(int? v) {
     // max 8 byte int + 1 control byte
     if (_buf.length - _offset < 9) _nextBuf();
     if (v == null) {
@@ -127,7 +127,7 @@ class Packer {
   }
 
   /// Pack [double] or `null`.
-  void packDouble(double v) {
+  void packDouble(double? v) {
     // 8 byte double + 1 control byte
     if (_buf.length - _offset < 9) _nextBuf();
     if (v == null) {
@@ -150,7 +150,7 @@ class Packer {
   /// ```
   /// - Empty and `null` distinguishable: no action required just save `p.packString(s)`.
   /// Throws [ArgumentError] if [String.length] exceed (2^32)-1.
-  void packString(String v) {
+  void packString(String? v) {
     // max 4 byte str header + 1 control byte
     if (_buf.length - _offset < 5) _nextBuf();
     if (v == null) {
@@ -181,8 +181,8 @@ class Packer {
   /// Convenient function that call [packString(v)] by passing empty [String] as `null`.
   ///
   /// Convenient when you not distinguish between empty [String] and null on msgpack wire.
-  /// See [packString(v)] method documentation for more details.
-  void packStringEmptyIsNull(String v) {
+  /// See [packString] method documentation for more details.
+  void packStringEmptyIsNull(String? v) {
     if (v == null || v.isEmpty)
       packNull();
     else
@@ -190,7 +190,7 @@ class Packer {
   }
 
   /// Pack `List<int>` or null.
-  void packBinary(List<int> buffer) {
+  void packBinary(List<int>? buffer) {
     // max 4 byte binary header + 1 control byte
     if (_buf.length - _offset < 5) _nextBuf();
     if (buffer == null) {
@@ -216,7 +216,7 @@ class Packer {
   }
 
   /// Pack [List.length] or `null`.
-  void packListLength(int length) {
+  void packListLength(int? length) {
     // max 4 length header + 1 control byte
     if (_buf.length - _offset < 5) _nextBuf();
     if (length == null) {
@@ -237,7 +237,7 @@ class Packer {
   }
 
   /// Pack [Map.length] or `null`.
-  void packMapLength(int length) {
+  void packMapLength(int? length) {
     // max 4 byte header + 1 control byte
     if (_buf.length - _offset < 5) _nextBuf();
     if (length == null) {

--- a/lib/src/unpacker.dart
+++ b/lib/src/unpacker.dart
@@ -24,9 +24,9 @@ class Unpacker {
   /// Unpack value if it exist. Otherwise returns `null`.
   ///
   /// Throws [FormatException] if value is not a bool,
-  bool unpackBool() {
+  bool? unpackBool() {
     final b = _d.getUint8(_offset);
-    bool v;
+    bool? v;
     if (b == 0xc2) {
       v = false;
       _offset += 1;
@@ -45,9 +45,9 @@ class Unpacker {
   /// Unpack value if it exist. Otherwise returns `null`.
   ///
   /// Throws [FormatException] if value is not an integer,
-  int unpackInt() {
+  int? unpackInt() {
     final b = _d.getUint8(_offset);
-    int v;
+    int? v;
     if (b <= 0x7f || b >= 0xe0) {
       /// Int value in fixnum range [-32..127] encoded in header 1 byte
       v = _d.getInt8(_offset);
@@ -88,9 +88,9 @@ class Unpacker {
   /// Unpack value if it exist. Otherwise returns `null`.
   ///
   /// Throws [FormatException] if value is not a Double.
-  double unpackDouble() {
+  double? unpackDouble() {
     final b = _d.getUint8(_offset);
-    double v;
+    double? v;
     if (b == 0xca) {
       v = _d.getFloat32(++_offset);
       _offset += 8;
@@ -110,7 +110,7 @@ class Unpacker {
   ///
   /// Empty
   /// Throws [FormatException] if value is not a String.
-  String unpackString() {
+  String? unpackString() {
     final b = _d.getUint8(_offset);
     if (b == 0xc0) {
       _offset += 1;
@@ -225,7 +225,7 @@ class Unpacker {
     return data.toList();
   }
 
-  Object _unpack() {
+  Object? _unpack() {
     final b = _d.getUint8(_offset);
     if (b <= 0x7f ||
         b >= 0xe0 ||
@@ -264,13 +264,9 @@ class Unpacker {
   /// Return types declared as [Object] instead of `dynamic` for safety reasons.
   /// You need explicitly cast to proper types. And in case with [Object]
   /// compiler checks will force you to do it whereas with `dynamic` it will not.
-  List<Object> unpackList() {
+  List<Object?> unpackList() {
     final length = unpackListLength();
-    final list = List<Object>(length);
-    for (int i = 0; i < length; i++) {
-      list[i] = _unpack();
-    }
-    return list;
+    return List.generate(length, (_) => _unpack());
   }
 
   /// Automatically unpacks `bytes` to [Map] where key and values has corresponding data types.
@@ -278,13 +274,9 @@ class Unpacker {
   /// Return types declared as [Object] instead of `dynamic` for safety reasons.
   /// You need explicitly cast to proper types. And in case with [Object]
   /// compiler checks will force you to do it whereas with `dynamic` it will not.
-  Map<Object, Object> unpackMap() {
+  Map<Object?, Object?> unpackMap() {
     final length = unpackMapLength();
-    final map = <Object, Object>{};
-    for (int i = 0; i < length; i++) {
-      map[_unpack()] = _unpack();
-    }
-    return map;
+    return {for (var i = 0; i < length; i++) _unpack(): _unpack()};
   }
 
   Exception _formatException(String type, int b) => FormatException(

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,49 +1,12 @@
 name: messagepack
 description: Streaming API implementation of MessagePack binary serialization format - msgpack.
-version: 0.1.2
+version: 0.2.0
 homepage: https://github.com/nailgilaziev/messagepack
 repository: https://github.com/nailgilaziev/messagepack
 
 environment:
-  sdk: ">=2.7.0 <3.0.0"
+  sdk: ">=2.12.0 <3.0.0"
 
 
 dev_dependencies:
-  test: ^1.12.0
-
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
-flutter:
-
-  # To add assets to your package, add an assets section, like this:
-  # assets:
-  #   - images/a_dot_burr.jpeg
-  #   - images/a_dot_ham.jpeg
-  #
-  # For details regarding assets in packages, see
-  # https://flutter.dev/assets-and-images/#from-packages
-  #
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # To add custom fonts to your package, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts in packages, see
-  # https://flutter.dev/custom-fonts/#from-packages
+  test: ^1.16.0

--- a/test/messagepack_test.dart
+++ b/test/messagepack_test.dart
@@ -4,7 +4,7 @@ import 'dart:math';
 import 'package:messagepack/messagepack.dart';
 import 'package:test/test.dart';
 
-int packUnpackInt(int v, {bool negative = false}) {
+int? packUnpackInt(int? v, {bool negative = false}) {
   final p = Packer();
   if (negative)
     p.packInt(v);
@@ -14,14 +14,14 @@ int packUnpackInt(int v, {bool negative = false}) {
   return u.unpackInt();
 }
 
-double packUnpackDouble(double v) {
+double? packUnpackDouble(double? v) {
   final p = Packer();
   p.packDouble(v);
   final u = Unpacker(p.takeBytes());
   return u.unpackDouble();
 }
 
-String packUnpackString(String v) {
+String? packUnpackString(String? v) {
   final p = Packer();
   p.packString(v);
   final u = Unpacker(p.takeBytes());
@@ -40,7 +40,7 @@ final ints = [
   128,
 ];
 
-final negativeInts = ints.map((e) => e == null ? null : -1 * e).toList()
+final negativeInts = ints.map<int?>((e) => e == null ? null : -1 * e).toList()
   ..add(-9223372036854775808);
 
 final doubles = [
@@ -150,11 +150,11 @@ void main() {
 
   void pack(Packer p, MapEntry<int, dynamic> e) {
     if (e.key == 0) p.packNull();
-    if (e.key == 1) p.packBool(e.value as bool);
-    if (e.key == 2) p.packInt(e.value as int);
-    if (e.key == 3) p.packInt(e.value as int);
-    if (e.key == 4) p.packDouble(e.value as double);
-    if (e.key == 5) p.packString(e.value as String);
+    if (e.key == 1) p.packBool(e.value as bool?);
+    if (e.key == 2) p.packInt(e.value as int?);
+    if (e.key == 3) p.packInt(e.value as int?);
+    if (e.key == 4) p.packDouble(e.value as double?);
+    if (e.key == 5) p.packString(e.value as String?);
   }
 
   dynamic unpack(Unpacker u, int type) {
@@ -250,16 +250,16 @@ void main() {
     final p = Packer();
     p.packListLength(list.length);
     for (int i = 0; i < 10; i++) {
-      p.packInt(list[i] as int);
+      p.packInt(list[i] as int?);
     }
     for (int i = 10; i < 13; i++) {
-      p.packString(list[i] as String);
+      p.packString(list[i] as String?);
     }
     for (int i = 13; i < 16; i++) {
-      p.packBool(list[i] as bool);
+      p.packBool(list[i] as bool?);
     }
     for (int i = 16; i < 21; i++) {
-      p.packDouble(list[i] as double);
+      p.packDouble(list[i] as double?);
     }
     final u = Unpacker(p.takeBytes());
     expect(u.unpackListLength(), equals(list.length));


### PR DESCRIPTION
Hi, and thanks for this package! This PR migrates it to [null safety](https://dart.dev/null-safety). I've kept the existing behavior for now, we might want to consider making the `pack`/`unpack` methods return non-nullable values in the future.