### PR TITLE
Implemented a generic packing function

### DIFF
--- a/lib/src/packer.dart
+++ b/lib/src/packer.dart
@@ -50,6 +50,30 @@ class Packer {
     ));
   }
 
+  // Pack generic value
+  void packGeneric(dynamic? v) {
+    switch(v.runtimeType) {
+      case int:
+        packInt(v as int?);
+        break;
+      case bool:
+        packBool(v as bool?);
+        break;
+      case double:
+        packDouble(v as double?);
+        break;
+      case String:
+        packString(v as String?);
+        break;
+      case List:
+        packBinary(v as List<int>?);
+        break;
+      default:
+        throw new TypeError();
+        break;
+    }
+  }
+
   /// Pack binary and string uses this internally.
   void _putBytes(List<int> bytes) {
     final length = bytes.length;


### PR DESCRIPTION
Using dart's dynamic keywords, I wrote up a function which uses the rest of the pack() functions within the packer class. I was using this library on one of my projects, and I wanted to be able to use this library to pack whatever datatype the client needs, so using dart's features I came up with this little function,