### PR TITLE
Add method to unpack binary data as Uint8List

### DIFF
--- a/lib/src/unpacker.dart
+++ b/lib/src/unpacker.dart
@@ -197,11 +197,11 @@ class Unpacker {
     return len;
   }
 
-  /// Unpack value if packed value is binary or `null`.
+  /// Unpack value as Uint8List if packed value is binary or `null`.
   ///
   /// Encoded in msgpack packet null unpacks to [List] with 0 length for convenience.
   /// Throws [FormatException] if value is not a binary.
-  List<int> unpackBinary() {
+  Uint8List unpackBinaryUint8() {
     final b = _d.getUint8(_offset);
     int len;
     if (b == 0xc4) {
@@ -222,7 +222,15 @@ class Unpacker {
     final data =
         Uint8List.view(_list.buffer, _list.offsetInBytes + _offset, len);
     _offset += len;
-    return data.toList();
+    return data;
+  }
+
+  /// Unpack value if packed value is binary or `null`.
+  ///
+  /// Encoded in msgpack packet null unpacks to [List] with 0 length for convenience.
+  /// Throws [FormatException] if value is not a binary.
+  List<int> unpackBinary() {
+    return unpackBinaryUint8().toList();
   }
 
   Object? _unpack() {

--- a/test/messagepack_test.dart
+++ b/test/messagepack_test.dart
@@ -114,12 +114,12 @@ class MyData {
   void add(int key, MyData child) => children[key] = child;
   @override
   bool operator ==(Object other) {
-    if (!(other is MyData &&
-        other.data == data &&
-        other.children.length == children.length)) return false;
+    if (!(other is MyData) ||
+        other.runtimeType != runtimeType ||
+        other.data != data ||
+        other.children.length != children.length) return false;
     for (final item in children.entries) {
-      if (!other.children.containsKey(item.key) ||
-          other.children[item.key] != item.value) return false;
+      if (other.children[item.key] != item.value) return false;
     }
     return true;
   }
@@ -127,8 +127,8 @@ class MyData {
   @override
   int get hashCode => Object.hash(data, children);
 
-  late int data;
-  late Map<int, MyData> children;
+  int data;
+  Map<int, MyData> children;
 }
 
 void main() {
@@ -388,13 +388,21 @@ void main() {
     p.packBool(true);
     p.packBinary(bytes2);
     p.packInt(3);
-    final u = Unpacker(p.takeBytes());
+    final packedBytes = p.takeBytes();
+    final u = Unpacker(packedBytes);
     expect(u.unpackBinary(), equals(empty));
     expect(u.unpackBinary(), equals(empty));
     expect(u.unpackBinary(), equals(bytes1));
     expect(u.unpackBool(), equals(true));
     expect(u.unpackBinary(), equals(bytes2));
     expect(u.unpackInt(), equals(3));
+    final u2 = Unpacker(packedBytes);
+    expect(u2.unpackBinaryUint8(), equals(empty));
+    expect(u2.unpackBinaryUint8(), equals(empty));
+    expect(u2.unpackBinaryUint8(), equals(bytes1));
+    expect(u2.unpackBool(), equals(true));
+    expect(u2.unpackBinaryUint8(), equals(bytes2));
+    expect(u2.unpackInt(), equals(3));
   });
 
   test('Manual int example [dependent]', () {


### PR DESCRIPTION
Also adds a test demonstrating how one might pack/unpack a recursive data structure.

Looks like this could close issue #6 as well. (I wasn't the only one who wanted to avoid unnecessary copying of data from one form to another!)